### PR TITLE
Removed code that opens browser tab since it is now being done in the CLI

### DIFF
--- a/client/build/dev-server.js
+++ b/client/build/dev-server.js
@@ -76,10 +76,6 @@ const readyPromise = new Promise(resolve => {
 console.log('> Starting dev server...')
 devMiddleware.waitUntilValid(() => {
   console.log('> Listening at ' + uri + '\n')
-  // when env is testing, don't need open it
-  if (autoOpenBrowser && process.env.NODE_ENV !== 'testing') {
-    opn(uri)
-  }
   _resolve()
 })
 


### PR DESCRIPTION
In the latest version of mevn-cli, there is already code in launch.js of mevn-cli to open the boilerplate in a browser tab. Hence, we do not need to put the code to open in the browser within the boilerplate code since it opens two tabs when running with the latest version of CLI.